### PR TITLE
AspectTypeCatalog class is introduced for replacing AspectType enum at generated folder 

### DIFF
--- a/Tests/CompositionTests/TestAspects.cs
+++ b/Tests/CompositionTests/TestAspects.cs
@@ -4,9 +4,9 @@ namespace Tests.CompositionTests
 {
 	public readonly struct BarAspect : IAspect
 	{
-		public static readonly Gum.Composer.AspectType ASPECT_TYPE = 0;
+		public static readonly AspectType ASPECT_TYPE = 0;
 		
-		public Gum.Composer.AspectType Type => ASPECT_TYPE;
+		public AspectType Type => ASPECT_TYPE;
 
 		public readonly int MyInt;
 		
@@ -18,9 +18,9 @@ namespace Tests.CompositionTests
 	
 	public readonly struct FooAspect : IAspect
 	{
-		public static readonly Gum.Composer.AspectType ASPECT_TYPE = 1;
+		public static readonly AspectType ASPECT_TYPE = 1;
 		
-		public Gum.Composer.AspectType Type => ASPECT_TYPE;
+		public AspectType Type => ASPECT_TYPE;
 
 		public readonly int MyInt;
 		


### PR DESCRIPTION
I have revised `AspectType` enum on `Generated/AspectType.cs` to AspectTypeCatalog static class. This improvement also eleminated the full namespace requirement on generated `Aspects`.   