### PR TITLE
Assembly definition filename (tests) changed

### DIFF
--- a/Tests/GumTests.asmdef
+++ b/Tests/GumTests.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Tests",
+    "name": "GumTests",
     "rootNamespace": "",
     "references": [
         "UnityEngine.TestRunner",


### PR DESCRIPTION
The Tests.asmdef filename was the same as the other framework files and there was a conflict.