### PR TITLE
fix non-posix compliant folder scheme on paths

### DIFF
--- a/Gum.Composer/CodeGen/CompositionCodeGenerator.cs
+++ b/Gum.Composer/CodeGen/CompositionCodeGenerator.cs
@@ -56,7 +56,7 @@ namespace Gum.Composer.CodeGen
 			StringBuilder argsStringBuilder = new StringBuilder();
 			StringBuilder aspectTypeCatalogStringBuilder = new StringBuilder();
 			StringBuilder ctorStringBuilder = new StringBuilder();
-			aspectFileStringBuilder.Append(NAMESPACE_TEMPLATE.Replace(NAMESPACE, UserConfig.NAMESPACE));
+			aspectFileStringBuilder.Append(NAMESPACE_TEMPLATE.Replace(NAMESPACE, PathConfig.NAMESPACE));
 			aspectFileStringBuilder.Append(LINE + "{");
 			foreach (AspectPrototype aspectPrototype in AspectFileReader.ReadAspects())
 			{
@@ -100,14 +100,14 @@ namespace Gum.Composer.CodeGen
 
 			aspectFileStringBuilder.Append(LINE + "}");
 
-			string aspectCatalogClassFile = $@"{UserConfig.OutputDirectoryPath}\{ASPECT_CATALOG_FILE}";
-			string aspectsFile = $@"{UserConfig.OutputDirectoryPath}\{ASPECTS_FILE}";
+			string aspectCatalogClassFile = Path.Combine(PathConfig.GetOutputDirectoryPath(), ASPECT_CATALOG_FILE);
+			string aspectsFile = Path.Combine(PathConfig.GetOutputDirectoryPath(), ASPECTS_FILE);
 
 			FilePathHelper.EnsureFilePath(aspectCatalogClassFile);
 			FilePathHelper.EnsureFilePath(aspectsFile);
 
 			File.WriteAllText(aspectCatalogClassFile, ASPECT_CATALOG_TEMPLATE
-				.Replace(NAMESPACE, UserConfig.NAMESPACE)
+				.Replace(NAMESPACE, PathConfig.NAMESPACE)
 				.Replace(CONTENT, aspectTypeCatalogStringBuilder.ToString()));
 			File.WriteAllText(aspectsFile, aspectFileStringBuilder.ToString());
 		}

--- a/Gum.Composer/CodeGen/Internal/AspectFileReader.cs
+++ b/Gum.Composer/CodeGen/Internal/AspectFileReader.cs
@@ -10,7 +10,7 @@ namespace Gum.Composer.CodeGen.Internal
 
 		public static IEnumerable<AspectPrototype> ReadAspects()
 		{
-			string[] files = Directory.GetFiles(UserConfig.AspectsDirectoryPath, SEARCH_PATTERN, SearchOption.AllDirectories);
+			string[] files = Directory.GetFiles(PathConfig.GetAspectsDirectoryPath(), SEARCH_PATTERN, SearchOption.AllDirectories);
 			List<AspectPrototype> aspectPrototypes = new List<AspectPrototype>();
 			for (int index = 0; index < files.Length; index++)
 			{

--- a/Gum.Composer/PathConfig.cs
+++ b/Gum.Composer/PathConfig.cs
@@ -1,0 +1,86 @@
+﻿using System.IO;
+using Gum.Core.Assert;
+using UnityEngine;
+
+namespace Gum.Composer
+{
+	internal static class PathConfig
+	{
+		private static readonly string ProjectDirectory = GetProjectDirectory(Directory.GetCurrentDirectory());
+
+		public const string NAMESPACE = @"Gum.Composer";
+		private const string FOLDER_SEARCH_PATTERN = "Assets";
+		private const string COMPOSER_FOLDER_PATH = "Composer";
+		private const string GENERATED_FOLDER_PATH = "Generated";
+		private const string GUM_FOLDER_PATH = "Gum";
+		private const string ASPECT_FOLDER_NAME_PATTERN = "Aspects";
+
+		private static string GetProjectDirectory(string directory)
+		{
+			if (TryGetProjectDirectory(directory, out string foundDirectory))
+			{
+				CreateRequiredFoldersIfNotExist(foundDirectory);
+				
+				return foundDirectory;
+			}
+
+			DirectoryInfo parentDirectoryInfo = Directory.GetParent(directory);
+			if (parentDirectoryInfo != null)
+			{
+				return GetProjectDirectory(parentDirectoryInfo.FullName);
+			}
+
+			throw new GumException("Unable to find Gum.Composer directory!");
+		}
+
+		private static bool TryGetProjectDirectory(string directory, out string foundDirectory)
+		{
+			foundDirectory = string.Empty;
+			
+			string[] directories =
+				Directory.GetDirectories(directory, FOLDER_SEARCH_PATTERN, SearchOption.AllDirectories);
+			if (directories.Length > 0)
+			{
+				foundDirectory = directories[0];
+				return true;
+			}
+
+			return false;
+		}
+
+		private static void CreateRequiredFoldersIfNotExist(string directoryPath)
+		{
+			string folderNamePattern = GetOutputFolderNamePattern();
+			
+			try
+			{
+				Directory.GetDirectories(directoryPath, folderNamePattern, SearchOption.AllDirectories);
+			}
+			catch (DirectoryNotFoundException directoryNotFoundException)
+			{
+				string outputFolderNamePattern = Path.Combine(directoryPath, folderNamePattern);
+				string outputAspectFolderNamePattern =
+					Path.Combine(outputFolderNamePattern, ASPECT_FOLDER_NAME_PATTERN);
+
+				Directory.CreateDirectory(outputFolderNamePattern);
+				Directory.CreateDirectory(outputAspectFolderNamePattern);
+			}
+		}
+
+		public static string GetOutputDirectoryPath()
+		{
+			return Path.Combine(ProjectDirectory, GetOutputFolderNamePattern());	
+		}
+
+		public static string GetAspectsDirectoryPath()
+		{
+			return Path.Combine(ProjectDirectory, GetOutputFolderNamePattern(),
+				ASPECT_FOLDER_NAME_PATTERN);
+		}
+
+		private static string GetOutputFolderNamePattern()
+		{
+			return Path.Combine(GUM_FOLDER_PATH, COMPOSER_FOLDER_PATH, GENERATED_FOLDER_PATH);
+		}
+	}
+}

--- a/Gum.Composer/Unity/Editor/AspectFileWriter.cs
+++ b/Gum.Composer/Unity/Editor/AspectFileWriter.cs
@@ -41,7 +41,7 @@ namespace Gum.Composer.Unity.Editor
                 }
                 
                 aspectStringBuilder.Replace(BODY, bodyStringBuilder.ToString());
-                string aspectFile = $@"{UserConfig.AspectsDirectoryPath}\{aspectName + FILE_EXTENTION}";
+                string aspectFile = Path.Combine(PathConfig.GetAspectsDirectoryPath(), aspectName + FILE_EXTENTION);
                 FilePathHelper.EnsureFilePath(aspectFile);
                 File.WriteAllText(aspectFile, aspectStringBuilder.ToString());
             }

--- a/Gum.Composer/Unity/Editor/TypeFileReader.cs
+++ b/Gum.Composer/Unity/Editor/TypeFileReader.cs
@@ -40,9 +40,9 @@ namespace Gum.Composer.Unity.Editor
 
         private static string GetTypeText()
         {
-            FilePathHelper.EnsureFilePath($@"{UserConfig.OutputDirectoryPath}\{TypeFileConfig.TYPES_FILE}");
+            FilePathHelper.EnsureFilePath(Path.Combine(PathConfig.GetOutputDirectoryPath(), TypeFileConfig.TYPES_FILE));
 
-            string[] files = Directory.GetFiles(UserConfig.OutputDirectoryPath, SEARCH_PATTERN,
+            string[] files = Directory.GetFiles(PathConfig.GetOutputDirectoryPath(), SEARCH_PATTERN,
                 SearchOption.AllDirectories);
             string text = File.ReadAllText(files[0]);
             return text;

--- a/Gum.Composer/Unity/Editor/TypeFileWriter.cs
+++ b/Gum.Composer/Unity/Editor/TypeFileWriter.cs
@@ -27,8 +27,8 @@ namespace Gum.Composer.Unity.Editor
 
             typeFileStringBuilder.Append(bodyStringBuilder.ToString());
 
-            string typeFilePath = $@"{UserConfig.OutputDirectoryPath}\{TypeFileConfig.TYPES_FILE}";
-
+            string typeFilePath = Path.Combine(PathConfig.GetOutputDirectoryPath(), TypeFileConfig.TYPES_FILE);
+            
             FilePathHelper.EnsureFilePath(typeFilePath);
             File.WriteAllText(typeFilePath, typeFileStringBuilder.ToString());
         }


### PR DESCRIPTION
In this brach, folder naming is made universal accross all operation systems with use of  `Path.Combine` method.